### PR TITLE
LMSA-8499 - ExternalTool model from Canvas needs to support complex o…

### DIFF
--- a/src/main/java/edu/iu/uits/lms/canvas/model/ExternalTool.java
+++ b/src/main/java/edu/iu/uits/lms/canvas/model/ExternalTool.java
@@ -51,5 +51,5 @@ public class ExternalTool {
    private Map<String, String> customFields;
 
    @JsonProperty("course_navigation")
-   private Map<String, String> courseNavigation;
+   private Map<String, Object> courseNavigation;
 }


### PR DESCRIPTION
…bjects inside the course_navigation map, not just strings.

Guessing it's an LTI 1.3 related change that is still undocumented.